### PR TITLE
Fix: TypeError: fetch failed

### DIFF
--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -1,7 +1,7 @@
-import { FormData } from 'formdata-node'
 import { v4 as uuidv4 } from 'uuid'
 
 import fs from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import { promisify, format } from 'node:util'
 import { performance, PerformanceObserver } from 'node:perf_hooks'
@@ -41,7 +41,6 @@ import {
 import CrashReporter from './crash-reporter.js'
 import { BStackLogger } from './bstackLogger.js'
 import { PercyLogger } from './Percy/PercyLogger.js'
-import { FileStream } from './fileStream.js'
 import type Percy from './Percy/Percy.js'
 import BrowserStackConfig from './config.js'
 import { setupExitHandlers } from './exitHandler.js'
@@ -462,14 +461,14 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
         const form = new FormData()
         if (app.app) {
             const fileName = path.basename(app.app)
-            form.append('file', new FileStream(fs.createReadStream(app.app)), fileName)
+            const fileBlob = new Blob([await readFile(app.app)])
+            form.append('file', fileBlob, fileName)
         }
         if (app.customId) {
             form.append('custom_id', app.customId)
         }
 
         const headers: any = {
-            'Content-Type': 'multipart/form-data',
             Authorization: getBasicAuthHeader(this._config.user as string, this._config.key as string),
         }
 

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -12,7 +12,6 @@ import type { GitRepoInfo } from 'git-repo-info'
 import gitRepoInfo from 'git-repo-info'
 import gitconfig from 'gitconfiglocal'
 import type { ColorName } from 'chalk'
-import { FormData } from 'formdata-node'
 import logPatcher from './logPatcher.js'
 import PerformanceTester from './performance-tester.js'
 
@@ -1217,6 +1216,7 @@ export async function uploadLogs(user: string | undefined, key: string | undefin
     fileStream.pipe(zip)
 
     const formData = new FormData()
+    // @ts-ignore
     formData.append('data', new FileStream(zip), 'logs.gz')
     formData.append('clientBuildUuid', clientBuildUuid)
 


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

#### Fixes two issues from #13722 in `wdio-browserstack-service` : 

- App upload functionality broken with error `TypeError: fetch failed [cause]: InvalidArgumentError: invalid content-length header`
- Upload zipped logs to BrowserStack (ignoring the TS type issue, since pass fileStream also works fine and didn't find a to pipe blob of zipped content to `fetch` - `formData`. Looking for the suggestion if any


## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO (v8), please raise another PR with the same changes against the `v8` branch.)

- [x] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
