### PR TITLE
fix: capture uploadLogs failures on SDK_UPLOAD_LOGS performance event

### DIFF
--- a/packages/wdio-browserstack-service/package.json
+++ b/packages/wdio-browserstack-service/package.json
@@ -47,7 +47,6 @@
     "browserstack-local": "^1.5.1",
     "chalk": "^5.3.0",
     "csv-writer": "^1.6.0",
-    "formdata-node": "5.0.1",
     "git-repo-info": "^2.1.1",
     "gitconfiglocal": "^2.1.0",
     "glob": "^11.0.0",

--- a/packages/wdio-browserstack-service/src/instrumentation/performance/performance-tester.ts
+++ b/packages/wdio-browserstack-service/src/instrumentation/performance/performance-tester.ts
@@ -316,6 +316,11 @@ export default class PerformanceTester {
     static end(event: string, success = true, failure?: string | unknown, details = {}) {
         performance.mark(event + '-end')
         performance.measure(event, event + '-start', event + '-end')
+        // Clear the start-mark guard so a subsequent start(event) for the same
+        // event actually marks a new start. Without this, start() short-circuits
+        // and the next end() measures from the original start mark — inflated
+        // durations in telemetry on every call after the first.
+        delete this.eventsMap[event + '-start']
         this.details[event] = Object.assign({ success, failure: util.format(failure) }, Object.assign(Object.assign({
             clientWorkerId: PerformanceTester.getClientWorkerId(),
             worker: PerformanceTester.getProcessId(),

--- a/packages/wdio-browserstack-service/src/launcher.ts
+++ b/packages/wdio-browserstack-service/src/launcher.ts
@@ -785,15 +785,15 @@ export default class BrowserstackLauncherService implements Services.ServiceInst
     }
 
     async _uploadServiceLogs() {
+        // uploadLogs records the SDK_UPLOAD_LOGS event with status/failure for every
+        // return path (no creds, archive failure, upload no-response, exception), so
+        // measureWrapper is no longer needed here.
         const clientBuildUuid = this._getClientBuildUuid()
-        await PerformanceTester.measureWrapper(PERFORMANCE_SDK_EVENTS.EVENTS.SDK_UPLOAD_LOGS, async () => {
-
-            const response = await uploadLogs(getBrowserStackUser(this._config), getBrowserStackKey(this._config), clientBuildUuid)
-            if (response) {
-                BStackLogger.info(`Upload response: ${JSON.stringify(response, null, 2)}`)
-                BStackLogger.logToFile(`Response - ${format(response)}`, 'debug')
-            }
-        })
+        const response = await uploadLogs(getBrowserStackUser(this._config), getBrowserStackKey(this._config), clientBuildUuid)
+        if (response) {
+            BStackLogger.info(`Upload response: ${JSON.stringify(response, null, 2)}`)
+            BStackLogger.logToFile(`Response - ${format(response)}`, 'debug')
+        }
     }
 
     private _removeCliOnlyCapabilityOptions(capabilities?: Capabilities.TestrunnerCapabilities | WebdriverIO.Capabilities) {

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -1454,8 +1454,10 @@ export async function uploadLogs(user: string | undefined, key: string | undefin
         })
 
         const formData = new FormData()
-        const tarGzBytes = fs.readFileSync(tarGzPath)
-        const file = new Blob([tarGzBytes], { type: 'application/x-gzip' })
+        // openAsBlob returns a Blob backed by a file descriptor — undici streams
+        // from disk during the upload instead of materialising the full archive
+        // in V8 heap (which readFileSync + new Blob([Buffer]) would do twice).
+        const file = await fs.openAsBlob(tarGzPath, { type: 'application/x-gzip' })
         formData.append('data', file, 'logs.tar.gz')
         formData.append('clientBuildUuid', clientBuildUuid)
 

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -1391,8 +1391,19 @@ export function getFailureObject(error: string|Error) {
 export const sleep = (ms = 100) => new Promise((resolve) => setTimeout(resolve, ms))
 
 export async function uploadLogs(user: string | undefined, key: string | undefined, clientBuildUuid: string) {
+    // Manual instrumentation: tag every return path on the SDK_UPLOAD_LOGS event so
+    // the metric identifies the specific reason logs were not uploaded (no creds,
+    // per-file copy failure, upload no-response, exception). measureWrapper would
+    // otherwise mark all non-throwing paths as success.
+    const eventName = PERFORMANCE_SDK_EVENTS.EVENTS.SDK_UPLOAD_LOGS
+    let success = true
+    let failure: string | undefined
+    PerformanceTester.start(eventName)
+
     try {
         if (!user || !key) {
+            success = false
+            failure = 'skipped: missing_credentials'
             BStackLogger.debug('Uploading logs failed due to no credentials')
             return
         }
@@ -1406,11 +1417,21 @@ export async function uploadLogs(user: string | undefined, key: string | undefin
             CLI_DEBUG_LOGS_FILE,
         ].filter(f => fs.existsSync(f))
 
-        const copiedFileNames = []
+        const copiedFileNames: string[] = []
+        const archiveAddFailures: string[] = []
         for (const f of filesToArchive) {
-            const dest = path.join(tmpDir, path.basename(f))
-            fs.copyFileSync(f, dest)
-            copiedFileNames.push(path.basename(f))
+            try {
+                const dest = path.join(tmpDir, path.basename(f))
+                fs.copyFileSync(f, dest)
+                copiedFileNames.push(path.basename(f))
+            } catch (copyErr) {
+                const msg = (copyErr as Error)?.message || String(copyErr)
+                archiveAddFailures.push(`${path.basename(f)}: ${msg}`)
+            }
+        }
+
+        if (archiveAddFailures.length > 0 && failure === undefined) {
+            failure = `archive_add_failed [${archiveAddFailures.length}]: ${archiveAddFailures.join('; ')}`.substring(0, 300)
         }
 
         await create(
@@ -1464,10 +1485,26 @@ export async function uploadLogs(user: string | undefined, key: string | undefin
             fs.unlinkSync(CLI_DEBUG_LOGS_FILE)
         }
 
+        if (!response) {
+            // nodeRequest swallows errors for the log-upload path and returns undefined;
+            // record the silent upload failure on the metric.
+            success = false
+            failure = 'upload_no_response'
+        } else if (response.status && response.status !== 'success') {
+            // Server-side rejection (e.g. "File not attached") — response is truthy
+            // but the upload didn't actually land.
+            success = false
+            failure = `upload_status: ${response.status}${response.message ? ' - ' + String(response.message).slice(0, 200) : ''}`
+        }
+
         return response
     } catch (error) {
+        success = false
+        failure = `uploadLogs exception: ${getErrorString(error)}`
         BStackLogger.error(`Error while uploading logs: ${getErrorString(error)}`)
         return null
+    } finally {
+        PerformanceTester.end(eventName, success, failure)
     }
 }
 

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -1429,6 +1429,7 @@ export async function uploadLogs(user: string | undefined, key: string | undefin
         }
 
         if (archiveAddFailures.length > 0 && failure === undefined) {
+            success = false
             failure = `archive_add_failed [${archiveAddFailures.length}]: ${archiveAddFailures.join('; ')}`.substring(0, 300)
         }
 

--- a/packages/wdio-browserstack-service/src/util.ts
+++ b/packages/wdio-browserstack-service/src/util.ts
@@ -13,7 +13,6 @@ import type { GitRepoInfo } from 'git-repo-info'
 import gitRepoInfo from 'git-repo-info'
 import gitconfig from 'gitconfiglocal'
 import type { ColorName } from 'chalk'
-import { FormData } from 'formdata-node'
 import { performance } from 'node:perf_hooks'
 import logPatcher from './logPatcher.js'
 import PerformanceTester from './instrumentation/performance/performance-tester.js'
@@ -51,7 +50,6 @@ import TestOpsConfig from './testOps/testOpsConfig.js'
 import type { StartBinSessionResponse } from '@browserstack/wdio-browserstack-service'
 import APIUtils from './cli/apiUtils.js'
 import { create } from 'tar'
-import { fileFromPath } from 'formdata-node/file-from-path'
 
 import AccessibilityScripts from './scripts/accessibility-scripts.js'
 
@@ -1455,7 +1453,8 @@ export async function uploadLogs(user: string | undefined, key: string | undefin
         })
 
         const formData = new FormData()
-        const file = await fileFromPath(tarGzPath)
+        const tarGzBytes = fs.readFileSync(tarGzPath)
+        const file = new Blob([tarGzBytes], { type: 'application/x-gzip' })
         formData.append('data', file, 'logs.tar.gz')
         formData.append('clientBuildUuid', clientBuildUuid)
 

--- a/packages/wdio-browserstack-service/tests/util.test.ts
+++ b/packages/wdio-browserstack-service/tests/util.test.ts
@@ -56,6 +56,8 @@ import {
     getTestPlanId,
 } from '../src/util.js'
 import * as bstackLogger from '../src/bstackLogger.js'
+import PerformanceTester from '../src/instrumentation/performance/performance-tester.js'
+import * as PERFORMANCE_SDK_EVENTS from '../src/instrumentation/performance/constants.js'
 import { BROWSERSTACK_OBSERVABILITY, TESTOPS_BUILD_COMPLETED_ENV, BROWSERSTACK_TESTHUB_JWT, BROWSERSTACK_ACCESSIBILITY, BROWSERSTACK_TEST_PLAN_ID } from '../src/constants.js'
 import * as testHubUtils from '../src/testHub/utils.js'
 import * as fs from 'node:fs/promises'
@@ -1563,32 +1565,101 @@ describe('frameworkSupportsHook', function () {
 describe('uploadLogs', function () {
     let tempLogFile: string
     let originalLogFilePath: string
+    let endSpy: ReturnType<typeof vi.spyOn>
 
-    beforeAll(async () => {
+    beforeAll(() => {
         tempLogFile = path.join(os.tmpdir(), 'test-logs.txt')
-        await fs.writeFile(tempLogFile, 'mock log content')
         // Store original log file path
         originalLogFilePath = bstackLogger.BStackLogger.logFilePath
         bstackLogger.BStackLogger.logFilePath = tempLogFile
     })
 
-    beforeEach(() => {
+    beforeEach(async () => {
+        // uploadLogs's cleanup unlinks the copied file from tmpdir; that path
+        // is the same as tempLogFile, so re-create it before every test.
+        await fs.writeFile(tempLogFile, 'mock log content')
         vi.mocked(fetch).mockClear()
         vi.mocked(fetch).mockResolvedValue(Response.json({ status: 'success', message: 'Logs uploaded Successfully' }))
+        endSpy = vi.spyOn(PerformanceTester, 'end')
+    })
+
+    afterEach(() => {
+        endSpy.mockRestore()
     })
 
     it('should return if user is undefined', async function () {
         await uploadLogs(undefined, 'some_key', 'some_uuid')
         expect(fetch).not.toHaveBeenCalled()
+        expect(endSpy).toHaveBeenCalledWith(
+            PERFORMANCE_SDK_EVENTS.EVENTS.SDK_UPLOAD_LOGS,
+            false,
+            'skipped: missing_credentials'
+        )
     })
+
     it('should return if key is undefined', async function () {
         await uploadLogs('some_user', undefined, 'some_uuid')
         expect(fetch).not.toHaveBeenCalled()
+        expect(endSpy).toHaveBeenCalledWith(
+            PERFORMANCE_SDK_EVENTS.EVENTS.SDK_UPLOAD_LOGS,
+            false,
+            'skipped: missing_credentials'
+        )
     })
+
     it('should upload the logs', async function () {
         await uploadLogs('some_user', 'some_key', 'some_uuid')
         expect(fetch).toHaveBeenCalled()
+        expect(endSpy).toHaveBeenCalledWith(
+            PERFORMANCE_SDK_EVENTS.EVENTS.SDK_UPLOAD_LOGS,
+            true,
+            undefined
+        )
     })
+
+    it('should send FormData with a Blob (native, not formdata-node)', async function () {
+        await uploadLogs('some_user', 'some_key', 'some_uuid')
+        expect(fetch).toHaveBeenCalled()
+        // The body passed to fetch should be a FormData with a `data` field containing
+        // a Blob/File so undici (native fetch) recognizes it as a file part. Sending
+        // formdata-node's FormData here causes undici to serialize the file as a
+        // string field and the server returns "File not attached".
+        const fetchCall = vi.mocked(fetch).mock.calls[0]
+        const opts: any = fetchCall[1]
+        expect(opts.body).toBeInstanceOf(FormData)
+        const dataField = (opts.body as FormData).get('data')
+        // In Node 18+, FormData.get for a file-like part returns a File/Blob.
+        // Either type is acceptable as long as it's a Blob (File extends Blob).
+        expect(dataField).toBeInstanceOf(Blob)
+        expect((opts.body as FormData).get('clientBuildUuid')).toBe('some_uuid')
+    })
+
+    it('should record upload_status when server rejects with non-success response', async function () {
+        vi.mocked(fetch).mockResolvedValueOnce(
+            Response.json({ status: 'failed', message: 'File not attached.' })
+        )
+        await uploadLogs('some_user', 'some_key', 'some_uuid')
+        expect(endSpy).toHaveBeenCalledWith(
+            PERFORMANCE_SDK_EVENTS.EVENTS.SDK_UPLOAD_LOGS,
+            false,
+            expect.stringContaining('upload_status: failed')
+        )
+        // The failure string should also surface the server message for diagnostics
+        expect(endSpy.mock.calls[0][2]).toContain('File not attached.')
+    })
+
+    it('should record upload_no_response when nodeRequest swallows the error and returns undefined', async function () {
+        // nodeRequest returns undefined for the log-upload path on AbortError / network failure;
+        // simulate that via a fetch reject — the inner catch in nodeRequest swallows it and returns undefined.
+        vi.mocked(fetch).mockRejectedValueOnce(new Error('socket hang up'))
+        await uploadLogs('some_user', 'some_key', 'some_uuid')
+        expect(endSpy).toHaveBeenCalledWith(
+            PERFORMANCE_SDK_EVENTS.EVENTS.SDK_UPLOAD_LOGS,
+            false,
+            'upload_no_response'
+        )
+    })
+
     afterAll(async () => {
         try {
             await fs.unlink(tempLogFile)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,7 +449,7 @@ importers:
         version: 5.2.4(vite@5.4.21(@types/node@25.3.5)(terser@5.43.1))(vue@3.5.29(typescript@5.9.3))
       expect-webdriverio:
         specifier: ^5.6.5
-        version: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0(puppeteer-core@24.34.0))
+        version: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.27.1(puppeteer-core@24.34.0))
       mocha:
         specifier: ^10.2.0
         version: 10.8.2
@@ -557,7 +557,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       expect-webdriverio:
         specifier: ^5.6.5
-        version: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0(puppeteer-core@24.34.0))
+        version: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.27.1(puppeteer-core@24.34.0))
       globals:
         specifier: ^16.5.0
         version: 16.5.0
@@ -795,9 +795,6 @@ importers:
       csv-writer:
         specifier: ^1.6.0
         version: 1.6.0
-      formdata-node:
-        specifier: 5.0.1
-        version: 5.0.1
       git-repo-info:
         specifier: ^2.1.1
         version: 2.1.1
@@ -1030,7 +1027,7 @@ importers:
     dependencies:
       expect-webdriverio:
         specifier: ^5.6.5
-        version: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0))
+        version: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0))
       webdriverio:
         specifier: ^9.0.0
         version: 9.16.2(puppeteer-core@24.34.0)
@@ -1183,7 +1180,7 @@ importers:
         version: 4.0.0
       expect-webdriverio:
         specifier: ^5.6.5
-        version: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.27.0(puppeteer-core@24.34.0))
+        version: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@packages+wdio-logger)(webdriverio@9.27.1(puppeteer-core@24.34.0))
       split2:
         specifier: ^4.1.0
         version: 4.2.0
@@ -4999,6 +4996,7 @@ packages:
   '@lerna/create@9.0.5':
     resolution: {integrity: sha512-Gwd6ooSqXMdkdhiCGvHAfLRstj7W3ttr72WQB3Jf9HPP1A6mWtw0O80D0X+T/2hakqfe7lNLuKrEid4f7C0qbg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    deprecated: This package is an implementation detail of Lerna and is no longer published separately.
 
   '@lit-labs/ssr-dom-shim@1.3.0':
     resolution: {integrity: sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==}
@@ -6955,8 +6953,8 @@ packages:
     resolution: {integrity: sha512-rcHu0eG16rSEmHL0sEKDcr/vYFmGhQ5GOlmlx54r+1sgh6sf136q+kth4169s16XqviWGW3LjZbUfpTK29pGtw==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/config@9.27.0':
-    resolution: {integrity: sha512-9y8z7ugIbU6ycKrA2SqCpKh1/hobut2rDq9CLt/BNVzSlebBBVOTMiAt1XroZzcPnA7/ZqpbkpOsbpPUaAQuNQ==}
+  '@wdio/config@9.27.1':
+    resolution: {integrity: sha512-QVfSCqcpMfVum9KlpxgjaLlSLXkc53UQ2CPJU+IUVBp8LkbSyeX972HQS8V9Hnn6vSPE1dYScItg7wblnJ8RQg==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/dot-reporter@9.16.2':
@@ -6973,8 +6971,8 @@ packages:
       expect-webdriverio: ^5.3.2
       webdriverio: ^9.0.0
 
-  '@wdio/globals@9.27.0':
-    resolution: {integrity: sha512-yT6EAyvEqm+wFD11fg89BMxvFkYLgnIVCihfJx+k73Gm3utL/DfZQpSheQdwrlQzu5p7jHi/JwOD76740F5Peg==}
+  '@wdio/globals@9.27.1':
+    resolution: {integrity: sha512-jm6gTQ6Qo3EOBY6PA09U/5Pf17WLEJM1/lTfhc6jzLFE770EuhuhbuphqrInH0hVR9WMyWtSZQ+LRCcLfcmOPQ==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       expect-webdriverio: ^5.6.5
@@ -6994,8 +6992,8 @@ packages:
   '@wdio/protocols@9.24.0':
     resolution: {integrity: sha512-ozQKYddBLT4TRvU9J+fGrhVUtx3iDAe+KNCJcTDMFMxNSdDMR2xFQdNp8HLHypspk58oXTYCvz6ZYjySthhqsw==}
 
-  '@wdio/protocols@9.27.0':
-    resolution: {integrity: sha512-rIk69BsY1+6uU2PEN5FiRpI6K7HJ86YHzZRFBe4iRzKXQgGNk1zWzbdVJIuNFoOWsnmYUkK42KSSOT4Le6EmiQ==}
+  '@wdio/protocols@9.27.1':
+    resolution: {integrity: sha512-Ril46AmySoiYX9nuKqFr3SNJqquU3VmF9FzSndQlDib0G3oA4pYx9wcBXvdvkFxRjjmFwQDzmvztKrssAHymgw==}
 
   '@wdio/repl@9.16.2':
     resolution: {integrity: sha512-FLTF0VL6+o5BSTCO7yLSXocm3kUnu31zYwzdsz4n9s5YWt83sCtzGZlZpt7TaTzb3jVUfxuHNQDTb8UMkCu0lQ==}
@@ -7020,8 +7018,8 @@ packages:
     resolution: {integrity: sha512-PYYunNl8Uq1r8YMJAK6ReRy/V/XIrCSyj5cpCtR5EqCL6heETOORFj7gt4uPnzidfgbtMBcCru0LgjjlMiH1UQ==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/types@9.27.0':
-    resolution: {integrity: sha512-DQJ+OdRBqUBcQ30DN2Z651hEVh3OoxnlDUSRqlWy9An2AY6v9rYWTj825B6zsj5pLLEToYO1tfwWq0ab183pXg==}
+  '@wdio/types@9.27.1':
+    resolution: {integrity: sha512-EHBNCvLmvpYerln4mb/OBxzKtnavL2wdenjhwuYjzkZMOWHgm/uLXH6sLThM0y6DIbCU72Asth16fo1eDcsofA==}
     engines: {node: '>=18.20.0'}
 
   '@wdio/utils@9.16.2':
@@ -7032,8 +7030,8 @@ packages:
     resolution: {integrity: sha512-6WhtzC5SNCGRBTkaObX6A07Ofnnyyf+TQH/d/fuhZRqvBknrP4AMMZF+PFxGl1fwdySWdBn+gV2QLE+52Byowg==}
     engines: {node: '>=18.20.0'}
 
-  '@wdio/utils@9.27.0':
-    resolution: {integrity: sha512-fUasd5OKJTy2seJfWnYZ9xlxTtY0p/Kyeuh7Tbb8kcofBqmBi2fTvM3sfZlo1tGQX9yCh+IS2N7hlfyFMmuZ+w==}
+  '@wdio/utils@9.27.1':
+    resolution: {integrity: sha512-s2w1tFrvmpdkZ33LYsIw4ONRdWIIm4MxkyIuibbcG1ILV5fFMS9rU59csHuWIM0KhJoEoLU+fzE3ze9O7TpWhw==}
     engines: {node: '>=18.20.0'}
 
   '@webassemblyjs/ast@1.14.1':
@@ -7084,6 +7082,7 @@ packages:
   '@xmldom/xmldom@0.9.8':
     resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -9594,10 +9593,6 @@ packages:
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
-
-  formdata-node@5.0.1:
-    resolution: {integrity: sha512-8xnIjMYGKPj+rY2BTbAmpqVpi8der/2FT4d9f7J32FlsCpO5EzZPq3C/N56zdv8KweHzVF6TGijsS1JT6r1H2g==}
-    engines: {node: '>= 14.17'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -14896,6 +14891,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -14904,15 +14900,17 @@ packages:
 
   uuid@3.3.2:
     resolution: {integrity: sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -15115,10 +15113,6 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
-
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
 
@@ -15133,8 +15127,8 @@ packages:
     resolution: {integrity: sha512-2R31Ey83NzMsafkl4hdFq6GlIBvOODQMkueLjeRqYAITu3QCYiq9oqBdnWA6CdePuV4dbKlYsKRX0mwMiPclDA==}
     engines: {node: '>=18.20.0'}
 
-  webdriver@9.27.0:
-    resolution: {integrity: sha512-w07ThZND48SIr0b4S7eFougYUyclmoUwdmju8yXvEJiXYjDjeYUpl8wZrYPEYRBylxpSx+sBHfEUBrPQkcTTRQ==}
+  webdriver@9.27.1:
+    resolution: {integrity: sha512-vr6h+RNQ75O2cofgVrdupGxtKjPEBaBYx/lHCHe0giJfAK01oL0U/yrOksJi7kmpev/daN93ldFPhlIlmWtv8Q==}
     engines: {node: '>=18.20.0'}
 
   webdriverio@9.16.2:
@@ -15155,8 +15149,8 @@ packages:
       puppeteer-core:
         optional: true
 
-  webdriverio@9.27.0:
-    resolution: {integrity: sha512-Y4FbMf4bKBXpPB0lYpglzQ2GfDDe6uojmMZl85uPyrDx18NW7mqN84ZawGoIg/FRvcLaVhcOzc98WOPo725Rag==}
+  webdriverio@9.27.1:
+    resolution: {integrity: sha512-iPaIU/DluYY7zfLiwXDdoLU/6ZW8eup4PNwQikrCzTfvH/ITllRhFUe6NRDTEEePSxxRTeXAn9nehCs98xWGVA==}
     engines: {node: '>=18.20.0'}
     peerDependencies:
       puppeteer-core: '>=22.x || <=24.x'
@@ -22909,11 +22903,11 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@wdio/config@9.27.0':
+  '@wdio/config@9.27.1':
     dependencies:
       '@wdio/logger': 9.18.0
-      '@wdio/types': 9.27.0
-      '@wdio/utils': 9.27.0
+      '@wdio/types': 9.27.1
+      '@wdio/utils': 9.27.1
       deepmerge-ts: 7.1.5
       glob: 10.5.0
       import-meta-resolve: 4.2.0
@@ -22956,15 +22950,15 @@ snapshots:
       expect-webdriverio: 5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@packages+wdio-logger)(webdriverio@packages+webdriverio)
       webdriverio: 9.16.2(puppeteer-core@24.34.0)
 
-  '@wdio/globals@9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.16.2(puppeteer-core@24.34.0))':
+  '@wdio/globals@9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.16.2(puppeteer-core@24.34.0))':
     dependencies:
-      expect-webdriverio: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0))
+      expect-webdriverio: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0))
       webdriverio: 9.16.2(puppeteer-core@24.34.0)
 
-  '@wdio/globals@9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0(puppeteer-core@24.34.0))':
+  '@wdio/globals@9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.27.1(puppeteer-core@24.34.0))':
     dependencies:
-      expect-webdriverio: 5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0(puppeteer-core@24.34.0))
-      webdriverio: 9.27.0(puppeteer-core@24.34.0)
+      expect-webdriverio: 5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.27.1(puppeteer-core@24.34.0))
+      webdriverio: 9.27.1(puppeteer-core@24.34.0)
 
   '@wdio/logger@9.16.2':
     dependencies:
@@ -22985,7 +22979,7 @@ snapshots:
 
   '@wdio/protocols@9.24.0': {}
 
-  '@wdio/protocols@9.27.0': {}
+  '@wdio/protocols@9.27.1': {}
 
   '@wdio/repl@9.16.2':
     dependencies:
@@ -23027,7 +23021,7 @@ snapshots:
     dependencies:
       '@types/node': 20.19.37
 
-  '@wdio/types@9.27.0':
+  '@wdio/types@9.27.1':
     dependencies:
       '@types/node': 20.19.37
 
@@ -23073,11 +23067,11 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@wdio/utils@9.27.0':
+  '@wdio/utils@9.27.1':
     dependencies:
       '@puppeteer/browsers': 2.13.0
       '@wdio/logger': 9.18.0
-      '@wdio/types': 9.27.0
+      '@wdio/types': 9.27.1
       decamelize: 6.0.1
       deepmerge-ts: 7.1.5
       edgedriver: 6.3.0
@@ -25817,35 +25811,35 @@ snapshots:
 
   expect-type@1.2.1: {}
 
-  expect-webdriverio@5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0)):
+  expect-webdriverio@5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.16.2(puppeteer-core@24.34.0)):
     dependencies:
       '@vitest/snapshot': 4.0.16
-      '@wdio/globals': 9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.16.2(puppeteer-core@24.34.0))
+      '@wdio/globals': 9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.16.2(puppeteer-core@24.34.0))
       '@wdio/logger': 9.18.0
       deep-eql: 5.0.2
       expect: 30.2.0
       jest-matcher-utils: 30.2.0
       webdriverio: 9.16.2(puppeteer-core@24.34.0)
 
-  expect-webdriverio@5.6.5(@wdio/globals@9.27.0)(@wdio/logger@9.18.0)(webdriverio@9.27.0(puppeteer-core@24.34.0)):
+  expect-webdriverio@5.6.5(@wdio/globals@9.27.1)(@wdio/logger@9.18.0)(webdriverio@9.27.1(puppeteer-core@24.34.0)):
     dependencies:
       '@vitest/snapshot': 4.0.16
-      '@wdio/globals': 9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0(puppeteer-core@24.34.0))
+      '@wdio/globals': 9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.27.1(puppeteer-core@24.34.0))
       '@wdio/logger': 9.18.0
       deep-eql: 5.0.2
       expect: 30.2.0
       jest-matcher-utils: 30.2.0
-      webdriverio: 9.27.0(puppeteer-core@24.34.0)
+      webdriverio: 9.27.1(puppeteer-core@24.34.0)
 
-  expect-webdriverio@5.6.5(@wdio/globals@9.27.0)(@wdio/logger@packages+wdio-logger)(webdriverio@9.27.0(puppeteer-core@24.34.0)):
+  expect-webdriverio@5.6.5(@wdio/globals@9.27.1)(@wdio/logger@packages+wdio-logger)(webdriverio@9.27.1(puppeteer-core@24.34.0)):
     dependencies:
       '@vitest/snapshot': 4.0.16
-      '@wdio/globals': 9.27.0(expect-webdriverio@5.6.5)(webdriverio@9.27.0(puppeteer-core@24.34.0))
+      '@wdio/globals': 9.27.1(expect-webdriverio@5.6.5)(webdriverio@9.27.1(puppeteer-core@24.34.0))
       '@wdio/logger': link:packages/wdio-logger
       deep-eql: 5.0.2
       expect: 30.2.0
       jest-matcher-utils: 30.2.0
-      webdriverio: 9.27.0(puppeteer-core@24.34.0)
+      webdriverio: 9.27.1(puppeteer-core@24.34.0)
 
   expect-webdriverio@5.6.5(@wdio/globals@packages+wdio-globals)(@wdio/logger@9.18.0)(webdriverio@packages+webdriverio):
     dependencies:
@@ -26202,11 +26196,6 @@ snapshots:
       mime-types: 2.1.35
 
   format@0.2.2: {}
-
-  formdata-node@5.0.1:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -32874,8 +32863,6 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-streams-polyfill@4.0.0-beta.3: {}
-
   web-vitals@4.2.4: {}
 
   webdriver-bidi-protocol@0.3.10: {}
@@ -32920,15 +32907,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriver@9.27.0:
+  webdriver@9.27.1:
     dependencies:
       '@types/node': 20.19.37
       '@types/ws': 8.18.1
-      '@wdio/config': 9.27.0
+      '@wdio/config': 9.27.1
       '@wdio/logger': 9.18.0
-      '@wdio/protocols': 9.27.0
-      '@wdio/types': 9.27.0
-      '@wdio/utils': 9.27.0
+      '@wdio/protocols': 9.27.1
+      '@wdio/types': 9.27.1
+      '@wdio/utils': 9.27.1
       deepmerge-ts: 7.1.5
       https-proxy-agent: 7.0.6
       undici: 6.24.1
@@ -33014,16 +33001,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webdriverio@9.27.0(puppeteer-core@24.34.0):
+  webdriverio@9.27.1(puppeteer-core@24.34.0):
     dependencies:
       '@types/node': 20.19.37
       '@types/sinonjs__fake-timers': 8.1.5
-      '@wdio/config': 9.27.0
+      '@wdio/config': 9.27.1
       '@wdio/logger': 9.18.0
-      '@wdio/protocols': 9.27.0
+      '@wdio/protocols': 9.27.1
       '@wdio/repl': 9.16.2
-      '@wdio/types': 9.27.0
-      '@wdio/utils': 9.27.0
+      '@wdio/types': 9.27.1
+      '@wdio/utils': 9.27.1
       archiver: 7.0.1
       aria-query: 5.3.2
       cheerio: 1.1.2
@@ -33040,7 +33027,7 @@ snapshots:
       rgb2hex: 0.2.5
       serialize-error: 12.0.0
       urlpattern-polyfill: 10.1.0
-      webdriver: 9.27.0
+      webdriver: 9.27.1
     optionalDependencies:
       puppeteer-core: 24.34.0
     transitivePeerDependencies:


### PR DESCRIPTION
The wdio-browserstack-service had several silent or partly-silent failure paths in uploadLogs that previously reported success on the SDK_UPLOAD_LOGS metric:

- !user || !key                     -> skipped: missing_credentials
- per-file fs.copyFileSync failure  -> archive_add_failed [<n>]: <file>: <err>; ...
- nodeRequest returned undefined    -> upload_no_response
- response.status !== 'success'     -> upload_status: <status> - <message>
- outer catch                       -> uploadLogs exception: <err>

measureWrapper only marks failure when the wrapped fn throws or rejects, so all five paths above resolved cleanly and the metric reported success even when no logs actually landed. Caught a real server-side rejection ("File not attached") in the webdriverio-browserstack sample run that was previously invisible.

Replace measureWrapper in _uploadServiceLogs with manual PerformanceTester.start/end inside uploadLogs itself, track status + failure as locals across every return path. Per-file copy failures aggregate into a single failure string capped at 300 chars.

Mirrors the patterns already landed in Python, Node, Java, and C# SDKs under SDK-5896.

## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Polish (an improvement for an existing feature)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (improvements to the project's docs)
- [ ] Specification changes (updates to WebDriver command specifications)
- [ ] Internal updates (everything related to internal scripts, governance documentation and CI files)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Backport Request

[//]: # (The current `main` branch is the development branch for WebdriverIO v9. If your change should be released to the current major version of WebdriverIO `v8`, please raise another PR with the same changes against the `v8` branch.)

- [ ] This change is solely for `v9` and doesn't need to be back-ported
- [ ] Back-ported PR at `#XXXXX`

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
